### PR TITLE
Complete catalog commands

### DIFF
--- a/br
+++ b/br
@@ -67,6 +67,8 @@ _br() {
     initial="access add-catalog application catalog deploy locations login version help"
     application="access add-children config delete effector entity invoke policy rename restart sensor set spec start stop"
     entity="access add-children config delete effector invoke policy rename restart sensor set spec start stop"
+    catalog="add delete list show"
+    cataloglist="application entity location policy"
 
     # Determine command state
     if [[ ${COMP_CWORD} == 1 ]] ; then
@@ -76,6 +78,14 @@ _br() {
     elif [[ "${COMP_WORDS[1]}" == "deploy" && ${COMP_CWORD} == 2 ]] ; then
         state=deploy
     elif [[ "${COMP_WORDS[1]}" == "add-catalog" && ${COMP_CWORD} == 2 ]] ; then
+        state=add-catalog
+    elif [[ "${COMP_WORDS[1]}" == "catalog" && ${COMP_CWORD} == 2 ]] ; then
+        state=catalog
+    elif [[ "${COMP_WORDS[1]}" == "catalog" && "${COMP_WORDS[2]}" == "list" && ${COMP_CWORD} == 3 ]] ; then
+        state=cataloglist
+    elif [[ "${COMP_WORDS[1]}" == "catalog" && "${COMP_WORDS[2]}" == "show" && ${COMP_CWORD} == 3 ]] ; then
+        state=cataloglist
+    elif [[ "${COMP_WORDS[1]}" == "catalog" && "${COMP_WORDS[2]}" == "add" && ${COMP_CWORD} == 3 ]] ; then
         state=add-catalog
     elif [[ "${COMP_WORDS[1]}" == "application" && ${COMP_CWORD} == 3 ]] ; then
         state=appid
@@ -146,6 +156,14 @@ _br() {
                 COMPREPLY=( $(compgen -W "${configlist}" -- "${cur}") )
                 COMPREPLY=$(printf %q%s "$COMPREPLY" "$last")
             fi
+            ;;
+        catalog)
+            COMPREPLY=( $(compgen -W "${catalog}" -- "${cur}") ) || return 1
+            COMPREPLY=$(printf %q%s "$COMPREPLY" "$last")
+            ;;
+        cataloglist)
+            COMPREPLY=( $(compgen -W "${cataloglist}" -- "${cur}") ) || return 1
+            COMPREPLY=$(printf %q%s "$COMPREPLY" "$last")
             ;;
         entity)
             local entitylist=$(entities ${appid})


### PR DESCRIPTION
Additional completion for `br catalog`. `add` is treated as if it were the now-deprecated `add-catalog`.